### PR TITLE
chore: Rename workflows

### DIFF
--- a/.github/workflows/build-pages.yaml
+++ b/.github/workflows/build-pages.yaml
@@ -1,4 +1,4 @@
-name: Deploy Mkdocs to GitHub Pages
+name: Build
 on:
   push:
     branches:

--- a/.github/workflows/lint-mkdocs.yaml
+++ b/.github/workflows/lint-mkdocs.yaml
@@ -1,11 +1,11 @@
-name: Lint MkDocs
+name: Lint
 
 on:
   push:
   workflow_dispatch:
 
 jobs:
-  build:
+  lint-mkdocs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Furiko Docs
 
-[![CC BY 4.0][cc-by-shield]][cc-by]
+[![Build](https://github.com/furiko-io/docs/actions/workflows/build-pages.yaml/badge.svg)](https://github.com/furiko-io/docs/actions/workflows/build-pages.yaml) [![CC BY 4.0][cc-by-shield]][cc-by]
 
 This repository contains the documentation site for <https://furiko.io>.
 


### PR DESCRIPTION
Add status badge to README, but we rename the workflow to make it more concise.