### PR TITLE
chore: Bump mkdocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mdx_truly_sane_lists
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-material==8.2.4
 pymdown-extensions


### PR DESCRIPTION
Latest version of Jinja2 breaks MkDocs 1.2.3: https://github.com/mkdocs/mkdocs/issues/2799

We will bump it to 1.3.0 since there doesn't seem to be any breaking changes.